### PR TITLE
Fix the cast exception when run gemfire repository example

### DIFF
--- a/quickstart/repository/src/main/java/org/springframework/data/gemfire/examples/CustomerService.java
+++ b/quickstart/repository/src/main/java/org/springframework/data/gemfire/examples/CustomerService.java
@@ -111,7 +111,7 @@ public class CustomerService {
 	 * Return all customers
 	 * @return
 	 */
-	public Set<Customer> findAllCustomers() {
+	public List<Customer> findAllCustomers() {
 		return customerRepository.findAll();
 	}
 }

--- a/quickstart/repository/src/main/java/org/springframework/data/gemfire/examples/repository/CustomerRepository.java
+++ b/quickstart/repository/src/main/java/org/springframework/data/gemfire/examples/repository/CustomerRepository.java
@@ -36,7 +36,7 @@ public interface CustomerRepository extends GemfireRepository<Customer, Long> {
 	 * 
 	 * @return
 	 */
-	Set<Customer> findAll();
+	List<Customer> findAll();
 
 	/**
 	 * Finds all {@link Customer}s with the given lastname.


### PR DESCRIPTION
This is related to #5 issue.

The problem is the interface of repository is using set instead of list.

While in the SimpleGemfireRepository findAll is casting the list explicitly, so the interface of repository can not use set.
@Override
public Collection findAll() {
SelectResults results = template.find("select \* from " + template.getRegion().getFullPath());
return (Collection)results.asList();
}
