### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@ Spring Data For Pivotal GemFire and Apache Geode Examples
 =========================================================
 
 This project provides a number of examples to get you started using Spring Data for Apache Geode or Pivotal GemFire.
-These examples are designed to work with [Spring Data for Pivotal GemFire] (http://projects.spring.io/spring-data-gemfire) 1.2
+These examples are designed to work with [Spring Data for Pivotal GemFire] (https://projects.spring.io/spring-data-gemfire) 1.2
 or higher and are organized into the following sub projects:
 
-> NOTE: [Apache Geode](http://geode.apache.org/) is the open source core
+> NOTE: [Apache Geode](https://geode.apache.org/) is the open source core
 of [Pivotal GemFire](https://pivotal.io/pivotal-gemfire).
 
 > NOTE: Where ever Pivotal GemFire is referenced, this equally applies to Apache Geode
@@ -21,7 +21,7 @@ such as Cache and Region.
 The Quickstart examples currently include:
 
 * spring-cache - Using Spring's Cache abstraction with Pivotal GemFire
-* repository - Using [Spring Data](http://projects.spring.io/spring-data) Repositories with Pivotal GemFire
+* repository - Using [Spring Data](https://projects.spring.io/spring-data) Repositories with Pivotal GemFire
 * gemfire-template - Using [GemfireTemplate](https://docs.spring.io/spring-data/geode/docs/current/api/org/springframework/data/gemfire/GemfireTemplate.html) to simplify and enhance accessing Region data
 * cq - Configuring and using Pivotal GemFire Continuous Queries
 * transaction - Demonstrates the use of Pivotal GemFire transactions
@@ -47,7 +47,7 @@ using Spring's Java-based Container Configuration and Spring Data for Pivotal Ge
 These examples demonstrate additional Apache Geode or Pivotal GemFire features
 and require a full installation of either Apache Geode or Pivotal GemFire.
 
-You can acquire Apache Geode bits from [here](http://geode.apache.org/releases/).
+You can acquire Apache Geode bits from [here](https://geode.apache.org/releases/).
 
 You can download a trial version of Pivotal GemFire from [here](https://pivotal.io/pivotal-gemfire).
 

--- a/advanced/README.md
+++ b/advanced/README.md
@@ -1,7 +1,7 @@
 Spring Data GemFire - Advanced Examples
 ========================================
 
-These examples demonstrate additional GemFire features and require a full installation of GemFire. A trial version may be obtained [here](http://www.vmware.com/products/application-platform/vfabric-gemfire/overview.html).
+These examples demonstrate additional GemFire features and require a full installation of GemFire. A trial version may be obtained [here](https://www.vmware.com/products/application-platform/vfabric-gemfire/overview.html).
 
 
 #Starting and Stopping Locators

--- a/advanced/gatewayV7/README.md
+++ b/advanced/gatewayV7/README.md
@@ -3,7 +3,7 @@ Spring Data GemFire - Gateway V7 Example
 
 See the [README](..README.md) in the advanced root directory for information about locators. 
 
-Note: This example requires a valid [GemFire license key](http://pubs.vmware.com/vfabric51/topic/com.vmware.vfabric.gemfire.6.6/deploying/licensing/licensing.html?resultof=%22%6c%69%63%65%6e%73%69%6e%67%22%20%22%6c%69%63%65%6e%73%22%20) for a Data Management Node. GemFire checks for a valid license before starting a gateway.
+Note: This example requires a valid [GemFire license key](https://pubs.vmware.com/vfabric51/topic/com.vmware.vfabric.gemfire.6.6/deploying/licensing/licensing.html?resultof=%22%6c%69%63%65%6e%73%69%6e%67%22%20%22%6c%69%63%65%6e%73%22%20) for a Data Management Node. GemFire checks for a valid license before starting a gateway.
 
 If you have downloaded the trial version, you will need to obtain a key from GemFire sales. Edit gateway.properties to set the license key:
 

--- a/basic/cq-with-javaconfig/README.md
+++ b/basic/cq-with-javaconfig/README.md
@@ -1,13 +1,13 @@
 GemFire Continuous Query (CQ) Configured with Spring JavaConfig
 ===============================================================
 
-This example demonstrates GemFire's [Continuous Query (CQ)](http://gemfire.docs.pivotal.io/geode/developing/continuous_querying/chapter_overview.html) functionality.
-Specifically, this example shows how to use _Spring's_ [Java-based Container Configuration](http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#beans-java)
-along with _Spring Data GemFire's_ [ContinuousQueryListenerContainer](http://docs.spring.io/spring-data-gemfire/docs/current/reference/html/#apis:cq-container)
+This example demonstrates GemFire's [Continuous Query (CQ)](https://gemfire.docs.pivotal.io/geode/developing/continuous_querying/chapter_overview.html) functionality.
+Specifically, this example shows how to use _Spring's_ [Java-based Container Configuration](https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#beans-java)
+along with _Spring Data GemFire's_ [ContinuousQueryListenerContainer](https://docs.spring.io/spring-data-gemfire/docs/current/reference/html/#apis:cq-container)
 declared in JavaConfig to define cache client _Continuous Queries_ (CQ),
 register for notifications and process CQ events.
 
-This examples uses GemFire's [client/server](http://gemfire.docs.pivotal.io/geode/topologies_and_comm/cs_configuration/chapter_overview.html)
+This examples uses GemFire's [client/server](https://gemfire.docs.pivotal.io/geode/topologies_and_comm/cs_configuration/chapter_overview.html)
 topology.
 
 The `Server` class in this example is a _Spring Boot_ application that bootstraps
@@ -16,7 +16,7 @@ and starts a GemFire `CacheServer` allowing cache clients to connect.
 In addition, it also creates a `/Orders` _Region_ in which `Orders`
 will be placed and CQ events generated.
 
-The application simulates `Orders` from `Customers` using _Spring's_ [scheduling infrastructure](http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#scheduling),
+The application simulates `Orders` from `Customers` using _Spring's_ [scheduling infrastructure](https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#scheduling),
 placing `Orders` into the `/Orders` _Region_.
 
 The `Client` class in this example is also a _Spring Boot_ application

--- a/basic/cq-with-javaconfig/src/main/java/org/springframework/data/gemfire/examples/client/Client.java
+++ b/basic/cq-with-javaconfig/src/main/java/org/springframework/data/gemfire/examples/client/Client.java
@@ -51,7 +51,7 @@ import org.apache.geode.cache.client.ClientRegionShortcut;
  * @see org.springframework.data.gemfire.listener.ContinuousQueryDefinition
  * @see org.springframework.data.gemfire.listener.ContinuousQueryListener
  * @see org.springframework.data.gemfire.listener.ContinuousQueryListenerContainer
- * @see <a href="http://gemfire.docs.pivotal.io/geode/developing/continuous_querying/chapter_overview.html">Continuous Query</a>
+ * @see <a href="https://gemfire.docs.pivotal.io/geode/developing/continuous_querying/chapter_overview.html">Continuous Query</a>
  * @since 2.0.0
  */
 @SpringBootApplication

--- a/basic/java-config/README.md
+++ b/basic/java-config/README.md
@@ -1,7 +1,7 @@
 GemFire Configuration Using Spring Java-based Container Configuration
 =====================================================================
 
-This example demonstrates how to configure a GemFire Server (data node) using _Spring's_ [Java-based Container Configuration](http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#beans-java)
+This example demonstrates how to configure a GemFire Server (data node) using _Spring's_ [Java-based Container Configuration](https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#beans-java)
 along with _Spring Data GemFire's_ custom [GemFire FactoryBean components and classes](https://github.com/spring-projects/spring-data-gemfire/tree/master/src/main/java/org/springframework/data/gemfire).
 
 After reviewing this example, a developer should gain a general understanding of how to configure a single GemFire Server

--- a/quickstart/gemfire-template/README.md
+++ b/quickstart/gemfire-template/README.md
@@ -19,9 +19,9 @@ Then import the project into your IDE and run Main.java
 This example demonstrates the use of GemfireTemplate to perform region data access. GemfireTemplate wraps the native
 GemFire Region and translates GemFire checked exceptions and native runtime exceptions to Spring's DataAccessException
 RuntimeException hierarchy. This plays well with Spring's [declarative transaction management]
-(http://static.springsource.org/spring/docs/current/spring-framework-reference/htmlsingle/spring-framework-reference.html#transaction). 
+(https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/spring-framework-reference.html#transaction). 
 The CustomerService class includes a deleteCustomer(...) method which deletes a Customer from the Customer Region and also deletes any of that 
 customer's orders from the Order region. This is an atomic unit of work, enclosed in a transaction by the 
-[GemfireTransactionManager](http://static.springsource.org/spring-gemfire/docs/current/reference/html/apis.html#apis:tx-mgmt) 
+[GemfireTransactionManager](https://docs.spring.io/spring-gemfire/docs/current/reference/html/apis.html#apis:tx-mgmt) 
 using @Transactional. 
 

--- a/quickstart/repository/README.md
+++ b/quickstart/repository/README.md
@@ -39,5 +39,5 @@ NOTE: This example uses a very simple GemFire configuration appropriate for unit
 backed by a local cache and is not persisted.
 
 In practice, GemFire should be configured so that the Repository region is distributed and replicated across multiple nodes. Disk 
-persistence is also available if needed. Refer to the GemFire [documentation] (http://www.vmware.com/support/pubs/vfabric-gemfire.html)  
-for more information. Also see the [spring data] (http://www.springsource.org/spring-data) project page for further details about Spring Data.  
+persistence is also available if needed. Refer to the GemFire [documentation] (https://www.vmware.com/support/pubs/vfabric-gemfire.html)  
+for more information. Also see the [spring data] (https://www.springsource.org/spring-data) project page for further details about Spring Data.  

--- a/quickstart/spring-cache/README.md
+++ b/quickstart/spring-cache/README.md
@@ -21,6 +21,6 @@ retrieved again the cached instance will be returned.
 The method CustomerService.findCustomer() is annotated with @Cacheable("Customer"), which refers to a GemFire Region named 'Customer'. 
 The GemFire cache and region are configured in cache-context.xml and the cacheManager are Spring beans configured in app-context.xml
 
-See [This section of the Spring Reference](http://static.springsource.org/spring/docs/current/spring-framework-reference/htmlsingle/spring-framework-reference.html#new-in-3.1-cache-abstraction) 
+See [This section of the Spring Reference](https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/spring-framework-reference.html#new-in-3.1-cache-abstraction) 
 for more information.
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://static.springsource.org/spring-gemfire/docs/current/reference/html/apis.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-gemfire/docs/current/reference/html/apis.html ([https](https://static.springsource.org/spring-gemfire/docs/current/reference/html/apis.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.spring.io/spring-data-gemfire/docs/current/reference/html/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-data-gemfire/docs/current/reference/html/ ([https](https://docs.spring.io/spring-data-gemfire/docs/current/reference/html/) result 200).
* [ ] http://geode.apache.org/ with 1 occurrences migrated to:  
  https://geode.apache.org/ ([https](https://geode.apache.org/) result 200).
* [ ] http://geode.apache.org/releases/ with 1 occurrences migrated to:  
  https://geode.apache.org/releases/ ([https](https://geode.apache.org/releases/) result 200).
* [ ] http://www.vmware.com/support/pubs/vfabric-gemfire.html with 1 occurrences migrated to:  
  https://www.vmware.com/support/pubs/vfabric-gemfire.html ([https](https://www.vmware.com/support/pubs/vfabric-gemfire.html) result 200).
* [ ] http://projects.spring.io/spring-data with 1 occurrences migrated to:  
  https://projects.spring.io/spring-data ([https](https://projects.spring.io/spring-data) result 301).
* [ ] http://projects.spring.io/spring-data-gemfire with 1 occurrences migrated to:  
  https://projects.spring.io/spring-data-gemfire ([https](https://projects.spring.io/spring-data-gemfire) result 301).
* [ ] http://pubs.vmware.com/vfabric51/topic/com.vmware.vfabric.gemfire.6.6/deploying/licensing/licensing.html?resultof=%22%6c%69%63%65%6e%73%69%6e%67%22%20%22%6c%69%63%65%6e%73%22%20 with 1 occurrences migrated to:  
  https://pubs.vmware.com/vfabric51/topic/com.vmware.vfabric.gemfire.6.6/deploying/licensing/licensing.html?resultof=%22%6c%69%63%65%6e%73%69%6e%67%22%20%22%6c%69%63%65%6e%73%22%20 ([https](https://pubs.vmware.com/vfabric51/topic/com.vmware.vfabric.gemfire.6.6/deploying/licensing/licensing.html?resultof=%22%6c%69%63%65%6e%73%69%6e%67%22%20%22%6c%69%63%65%6e%73%22%20) result 301).
* [ ] http://www.springsource.org/spring-data with 1 occurrences migrated to:  
  https://www.springsource.org/spring-data ([https](https://www.springsource.org/spring-data) result 301).
* [ ] http://www.vmware.com/products/application-platform/vfabric-gemfire/overview.html with 1 occurrences migrated to:  
  https://www.vmware.com/products/application-platform/vfabric-gemfire/overview.html ([https](https://www.vmware.com/products/application-platform/vfabric-gemfire/overview.html) result 301).
* [ ] http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/ with 3 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/ ([https](https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/) result 302).
* [ ] http://static.springsource.org/spring/docs/current/spring-framework-reference/htmlsingle/spring-framework-reference.html (301) with 2 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/spring-framework-reference.html ([https](https://static.springsource.org/spring/docs/current/spring-framework-reference/htmlsingle/spring-framework-reference.html) result 302).
* [ ] http://gemfire.docs.pivotal.io/geode/developing/continuous_querying/chapter_overview.html with 2 occurrences migrated to:  
  https://gemfire.docs.pivotal.io/geode/developing/continuous_querying/chapter_overview.html ([https](https://gemfire.docs.pivotal.io/geode/developing/continuous_querying/chapter_overview.html) result 302).
* [ ] http://gemfire.docs.pivotal.io/geode/topologies_and_comm/cs_configuration/chapter_overview.html with 1 occurrences migrated to:  
  https://gemfire.docs.pivotal.io/geode/topologies_and_comm/cs_configuration/chapter_overview.html ([https](https://gemfire.docs.pivotal.io/geode/topologies_and_comm/cs_configuration/chapter_overview.html) result 302).