### PR TITLE
URL Cleanup

### DIFF
--- a/advanced/gatewayV7/src/main/java/org/springframework/data/gemfire/examples/GatewayExample.java
+++ b/advanced/gatewayV7/src/main/java/org/springframework/data/gemfire/examples/GatewayExample.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/advanced/gatewayV7/src/main/java/org/springframework/data/gemfire/examples/London.java
+++ b/advanced/gatewayV7/src/main/java/org/springframework/data/gemfire/examples/London.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/advanced/gatewayV7/src/main/java/org/springframework/data/gemfire/examples/NewYork.java
+++ b/advanced/gatewayV7/src/main/java/org/springframework/data/gemfire/examples/NewYork.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/advanced/locator-failover/src/main/java/org/springframework/data/gemfire/examples/Client.java
+++ b/advanced/locator-failover/src/main/java/org/springframework/data/gemfire/examples/Client.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/advanced/locator-failover/src/main/java/org/springframework/data/gemfire/examples/Server.java
+++ b/advanced/locator-failover/src/main/java/org/springframework/data/gemfire/examples/Server.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/annotated-function/src/main/java/org/springframework/data/gemfire/examples/Client.java
+++ b/basic/annotated-function/src/main/java/org/springframework/data/gemfire/examples/Client.java
@@ -6,7 +6,7 @@ package org.springframework.data.gemfire.examples;
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/annotated-function/src/main/java/org/springframework/data/gemfire/examples/Server.java
+++ b/basic/annotated-function/src/main/java/org/springframework/data/gemfire/examples/Server.java
@@ -6,7 +6,7 @@ package org.springframework.data.gemfire.examples;
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/annotated-function/src/main/java/org/springframework/data/gemfire/examples/client/ClientConfig.java
+++ b/basic/annotated-function/src/main/java/org/springframework/data/gemfire/examples/client/ClientConfig.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/basic/annotated-function/src/main/java/org/springframework/data/gemfire/examples/client/SalesCalculator.java
+++ b/basic/annotated-function/src/main/java/org/springframework/data/gemfire/examples/client/SalesCalculator.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/basic/annotated-function/src/main/java/org/springframework/data/gemfire/examples/server/SalesFunctions.java
+++ b/basic/annotated-function/src/main/java/org/springframework/data/gemfire/examples/server/SalesFunctions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/annotated-function/src/main/java/org/springframework/data/gemfire/examples/server/ServerConfig.java
+++ b/basic/annotated-function/src/main/java/org/springframework/data/gemfire/examples/server/ServerConfig.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/basic/cq-with-javaconfig/src/main/java/org/springframework/data/gemfire/examples/client/Client.java
+++ b/basic/cq-with-javaconfig/src/main/java/org/springframework/data/gemfire/examples/client/Client.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/cq-with-javaconfig/src/main/java/org/springframework/data/gemfire/examples/server/Server.java
+++ b/basic/cq-with-javaconfig/src/main/java/org/springframework/data/gemfire/examples/server/Server.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/function/src/main/java/org/springframework/data/gemfire/examples/CalculateTotalSalesForProduct.java
+++ b/basic/function/src/main/java/org/springframework/data/gemfire/examples/CalculateTotalSalesForProduct.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/function/src/main/java/org/springframework/data/gemfire/examples/CalculateTotalSalesForProductInvoker.java
+++ b/basic/function/src/main/java/org/springframework/data/gemfire/examples/CalculateTotalSalesForProductInvoker.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/function/src/main/java/org/springframework/data/gemfire/examples/Client.java
+++ b/basic/function/src/main/java/org/springframework/data/gemfire/examples/Client.java
@@ -6,7 +6,7 @@ package org.springframework.data.gemfire.examples;
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/function/src/main/java/org/springframework/data/gemfire/examples/Server.java
+++ b/basic/function/src/main/java/org/springframework/data/gemfire/examples/Server.java
@@ -6,7 +6,7 @@ package org.springframework.data.gemfire.examples;
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/partitioned/src/main/java/org/springframework/data/gemfire/examples/Client.java
+++ b/basic/partitioned/src/main/java/org/springframework/data/gemfire/examples/Client.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/partitioned/src/main/java/org/springframework/data/gemfire/examples/OrderKey.java
+++ b/basic/partitioned/src/main/java/org/springframework/data/gemfire/examples/OrderKey.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/basic/partitioned/src/main/java/org/springframework/data/gemfire/examples/PartitionedOrderKey.java
+++ b/basic/partitioned/src/main/java/org/springframework/data/gemfire/examples/PartitionedOrderKey.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/basic/partitioned/src/main/java/org/springframework/data/gemfire/examples/Server.java
+++ b/basic/partitioned/src/main/java/org/springframework/data/gemfire/examples/Server.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/persistence/src/main/java/org/springframework/data/gemfire/examples/Main.java
+++ b/basic/persistence/src/main/java/org/springframework/data/gemfire/examples/Main.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/replicated-cs/src/main/java/org/springframework/data/gemfire/examples/Client.java
+++ b/basic/replicated-cs/src/main/java/org/springframework/data/gemfire/examples/Client.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/replicated-cs/src/main/java/org/springframework/data/gemfire/examples/Server.java
+++ b/basic/replicated-cs/src/main/java/org/springframework/data/gemfire/examples/Server.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/replicated/src/main/java/org/springframework/data/gemfire/examples/Consumer.java
+++ b/basic/replicated/src/main/java/org/springframework/data/gemfire/examples/Consumer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/replicated/src/main/java/org/springframework/data/gemfire/examples/Producer.java
+++ b/basic/replicated/src/main/java/org/springframework/data/gemfire/examples/Producer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/write-through/src/main/java/org/springframework/data/gemfire/examples/Main.java
+++ b/basic/write-through/src/main/java/org/springframework/data/gemfire/examples/Main.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/write-through/src/main/java/org/springframework/data/gemfire/examples/ProductDBLoader.java
+++ b/basic/write-through/src/main/java/org/springframework/data/gemfire/examples/ProductDBLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/write-through/src/main/java/org/springframework/data/gemfire/examples/ProductDBWriter.java
+++ b/basic/write-through/src/main/java/org/springframework/data/gemfire/examples/ProductDBWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/basic/write-through/src/main/java/org/springframework/data/gemfire/examples/repository/ProductRepository.java
+++ b/basic/write-through/src/main/java/org/springframework/data/gemfire/examples/repository/ProductRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/quickstart/cq/src/main/java/org/springframework/data/gemfire/examples/CQListener.java
+++ b/quickstart/cq/src/main/java/org/springframework/data/gemfire/examples/CQListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/quickstart/cq/src/main/java/org/springframework/data/gemfire/examples/Client.java
+++ b/quickstart/cq/src/main/java/org/springframework/data/gemfire/examples/Client.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/quickstart/cq/src/main/java/org/springframework/data/gemfire/examples/Server.java
+++ b/quickstart/cq/src/main/java/org/springframework/data/gemfire/examples/Server.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/quickstart/gemfire-template/src/main/java/org/springframework/data/gemfire/examples/CustomerDao.java
+++ b/quickstart/gemfire-template/src/main/java/org/springframework/data/gemfire/examples/CustomerDao.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/quickstart/gemfire-template/src/main/java/org/springframework/data/gemfire/examples/CustomerService.java
+++ b/quickstart/gemfire-template/src/main/java/org/springframework/data/gemfire/examples/CustomerService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/quickstart/gemfire-template/src/main/java/org/springframework/data/gemfire/examples/GemfireTemplateCustomerDao.java
+++ b/quickstart/gemfire-template/src/main/java/org/springframework/data/gemfire/examples/GemfireTemplateCustomerDao.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/quickstart/gemfire-template/src/main/java/org/springframework/data/gemfire/examples/GemfireTemplateOrderDao.java
+++ b/quickstart/gemfire-template/src/main/java/org/springframework/data/gemfire/examples/GemfireTemplateOrderDao.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/quickstart/gemfire-template/src/main/java/org/springframework/data/gemfire/examples/Main.java
+++ b/quickstart/gemfire-template/src/main/java/org/springframework/data/gemfire/examples/Main.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/quickstart/gemfire-template/src/main/java/org/springframework/data/gemfire/examples/OrderDao.java
+++ b/quickstart/gemfire-template/src/main/java/org/springframework/data/gemfire/examples/OrderDao.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/quickstart/gemfire-template/src/main/java/org/springframework/data/gemfire/examples/OrderExample.java
+++ b/quickstart/gemfire-template/src/main/java/org/springframework/data/gemfire/examples/OrderExample.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/quickstart/gemfire-template/src/main/java/org/springframework/data/gemfire/examples/OrderService.java
+++ b/quickstart/gemfire-template/src/main/java/org/springframework/data/gemfire/examples/OrderService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/quickstart/json/src/main/java/org/springframework/data/gemfire/examples/JSONCustomerExample.java
+++ b/quickstart/json/src/main/java/org/springframework/data/gemfire/examples/JSONCustomerExample.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/quickstart/json/src/main/java/org/springframework/data/gemfire/examples/Main.java
+++ b/quickstart/json/src/main/java/org/springframework/data/gemfire/examples/Main.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/quickstart/repository/src/main/java/org/springframework/data/gemfire/examples/ApplicationConfig.java
+++ b/quickstart/repository/src/main/java/org/springframework/data/gemfire/examples/ApplicationConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/quickstart/repository/src/main/java/org/springframework/data/gemfire/examples/CustomerService.java
+++ b/quickstart/repository/src/main/java/org/springframework/data/gemfire/examples/CustomerService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/quickstart/repository/src/main/java/org/springframework/data/gemfire/examples/Main.java
+++ b/quickstart/repository/src/main/java/org/springframework/data/gemfire/examples/Main.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/quickstart/repository/src/main/java/org/springframework/data/gemfire/examples/OrderExample.java
+++ b/quickstart/repository/src/main/java/org/springframework/data/gemfire/examples/OrderExample.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/quickstart/repository/src/main/java/org/springframework/data/gemfire/examples/OrderService.java
+++ b/quickstart/repository/src/main/java/org/springframework/data/gemfire/examples/OrderService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/quickstart/repository/src/main/java/org/springframework/data/gemfire/examples/repository/CustomerRepository.java
+++ b/quickstart/repository/src/main/java/org/springframework/data/gemfire/examples/repository/CustomerRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/quickstart/repository/src/main/java/org/springframework/data/gemfire/examples/repository/OrderRepository.java
+++ b/quickstart/repository/src/main/java/org/springframework/data/gemfire/examples/repository/OrderRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/quickstart/repository/src/main/java/org/springframework/data/gemfire/examples/repository/ProductRepository.java
+++ b/quickstart/repository/src/main/java/org/springframework/data/gemfire/examples/repository/ProductRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/quickstart/spring-cache/src/main/java/org/springframework/data/gemfire/examples/CustomerDao.java
+++ b/quickstart/spring-cache/src/main/java/org/springframework/data/gemfire/examples/CustomerDao.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/quickstart/spring-cache/src/main/java/org/springframework/data/gemfire/examples/CustomerService.java
+++ b/quickstart/spring-cache/src/main/java/org/springframework/data/gemfire/examples/CustomerService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/quickstart/spring-cache/src/main/java/org/springframework/data/gemfire/examples/HashMapCustomerDao.java
+++ b/quickstart/spring-cache/src/main/java/org/springframework/data/gemfire/examples/HashMapCustomerDao.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/quickstart/spring-cache/src/main/java/org/springframework/data/gemfire/examples/Main.java
+++ b/quickstart/spring-cache/src/main/java/org/springframework/data/gemfire/examples/Main.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/quickstart/transaction/src/main/java/org/springframework/data/gemfire/examples/ApplicationConfig.java
+++ b/quickstart/transaction/src/main/java/org/springframework/data/gemfire/examples/ApplicationConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/quickstart/transaction/src/main/java/org/springframework/data/gemfire/examples/CustomerService.java
+++ b/quickstart/transaction/src/main/java/org/springframework/data/gemfire/examples/CustomerService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/quickstart/transaction/src/main/java/org/springframework/data/gemfire/examples/Main.java
+++ b/quickstart/transaction/src/main/java/org/springframework/data/gemfire/examples/Main.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/quickstart/transaction/src/main/java/org/springframework/data/gemfire/examples/repository/CustomerRepository.java
+++ b/quickstart/transaction/src/main/java/org/springframework/data/gemfire/examples/repository/CustomerRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-gemfire-examples-common/src/main/java/org/springframework/data/gemfire/examples/domain/AbstractPersistentEntity.java
+++ b/spring-gemfire-examples-common/src/main/java/org/springframework/data/gemfire/examples/domain/AbstractPersistentEntity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-gemfire-examples-common/src/main/java/org/springframework/data/gemfire/examples/domain/Address.java
+++ b/spring-gemfire-examples-common/src/main/java/org/springframework/data/gemfire/examples/domain/Address.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-gemfire-examples-common/src/main/java/org/springframework/data/gemfire/examples/domain/Customer.java
+++ b/spring-gemfire-examples-common/src/main/java/org/springframework/data/gemfire/examples/domain/Customer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-gemfire-examples-common/src/main/java/org/springframework/data/gemfire/examples/domain/EmailAddress.java
+++ b/spring-gemfire-examples-common/src/main/java/org/springframework/data/gemfire/examples/domain/EmailAddress.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-gemfire-examples-common/src/main/java/org/springframework/data/gemfire/examples/domain/LineItem.java
+++ b/spring-gemfire-examples-common/src/main/java/org/springframework/data/gemfire/examples/domain/LineItem.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-gemfire-examples-common/src/main/java/org/springframework/data/gemfire/examples/domain/Order.java
+++ b/spring-gemfire-examples-common/src/main/java/org/springframework/data/gemfire/examples/domain/Order.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-gemfire-examples-common/src/main/java/org/springframework/data/gemfire/examples/domain/Product.java
+++ b/spring-gemfire-examples-common/src/main/java/org/springframework/data/gemfire/examples/domain/Product.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-gemfire-examples-common/src/main/java/org/springframework/data/gemfire/examples/util/LoggingCacheListener.java
+++ b/spring-gemfire-examples-common/src/main/java/org/springframework/data/gemfire/examples/util/LoggingCacheListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-gemfire-examples-common/src/main/java/org/springframework/data/gemfire/examples/util/ServerPortGenerator.java
+++ b/spring-gemfire-examples-common/src/main/java/org/springframework/data/gemfire/examples/util/ServerPortGenerator.java
@@ -4,7 +4,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-gemfire-examples-common/src/main/java/org/springframework/data/gemfire/examples/util/Version.java
+++ b/spring-gemfire-examples-common/src/main/java/org/springframework/data/gemfire/examples/util/Version.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 69 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).